### PR TITLE
fix missing ';' from vagrant plugin install step

### DIFF
--- a/resources/common.mk
+++ b/resources/common.mk
@@ -82,7 +82,7 @@ install-requirements:
 	@ ansible-galaxy install -r ../resources/requirements.yml -p ../resources/roles && \
 	VBG_PLUGIN=`vagrant plugin list | grep vagrant-vbguest || true` && \
 	if [ -z "$$VBG_PLUGIN" ]; then \
-		vagrant plugin install vagrant-vbguest \
+		vagrant plugin install vagrant-vbguest; \
 	else \
 		echo "vagrant-vbguest is already installed"; \
 	fi


### PR DESCRIPTION
Missing ';' from plugin step was causing the make file to fail